### PR TITLE
dev rmarkdown for vignettes <3.6

### DIFF
--- a/.github/workflows/check-linux-ubuntu.yaml
+++ b/.github/workflows/check-linux-ubuntu.yaml
@@ -83,6 +83,9 @@ jobs:
           PGPASSWORD: ${{ env.DBROOTPASS }}
           MYSQL_PWD: ${{ env.DBROOTPASS }}
 
+      - name: test R cmd
+        run: R CMD build
+
       - name: Check
         run: Rscript -e "rcmdcheck::rcmdcheck(args = '${{ matrix.config.args }}', error_on = 'note', check_dir = 'check')"
 

--- a/.github/workflows/check-linux-ubuntu.yaml
+++ b/.github/workflows/check-linux-ubuntu.yaml
@@ -70,6 +70,9 @@ jobs:
       - name: Install R dependencies
         run: Rscript -e "install.packages(c('remotes', 'rcmdcheck', 'httptest'), type = 'source')" -e "remotes::install_deps(dependencies = TRUE);"
 
+      - name: Install dev rmarkdown
+        run: Rscript -e "remotes::install_github('rstudio/rmarkdown')"
+
       - name: Build R DB Dependencies on cache miss
         if: steps.rlibcache.outputs.cache-hit != 'true'
         run: Rscript -e "install.packages(c('RMariaDB', 'odbc', 'RPostgreSQL', 'RPostgres'), type = 'source');"
@@ -79,9 +82,6 @@ jobs:
         env:
           PGPASSWORD: ${{ env.DBROOTPASS }}
           MYSQL_PWD: ${{ env.DBROOTPASS }}
-
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v2
 
       - name: Check
         run: Rscript -e "rcmdcheck::rcmdcheck(args = '${{ matrix.config.args }}', error_on = 'note', check_dir = 'check')"

--- a/.github/workflows/check-linux-ubuntu.yaml
+++ b/.github/workflows/check-linux-ubuntu.yaml
@@ -32,7 +32,7 @@ jobs:
           r-version: ${{ matrix.config.r }}
 
       - name: test
-        run: Rscript -e 'print(tools:::.check_packages)'
+        run: Rscript -e 'print(tools:::.build_packages)'
 
       - uses: r-lib/actions/setup-pandoc@master
 

--- a/.github/workflows/check-linux-ubuntu.yaml
+++ b/.github/workflows/check-linux-ubuntu.yaml
@@ -84,7 +84,7 @@ jobs:
           MYSQL_PWD: ${{ env.DBROOTPASS }}
 
       - name: test R cmd
-        run: R CMD build
+        run: R CMD build .
 
       - name: Check
         run: Rscript -e "rcmdcheck::rcmdcheck(args = '${{ matrix.config.args }}', error_on = 'note', check_dir = 'check')"

--- a/.github/workflows/check-linux-ubuntu.yaml
+++ b/.github/workflows/check-linux-ubuntu.yaml
@@ -31,6 +31,9 @@ jobs:
         with:
           r-version: ${{ matrix.config.r }}
 
+      - name: test
+        run: Rscript -e 'installed.packages()["tools",]'
+
       - uses: r-lib/actions/setup-pandoc@master
 
       - uses: r-lib/actions/setup-tinytex@master

--- a/.github/workflows/check-linux-ubuntu.yaml
+++ b/.github/workflows/check-linux-ubuntu.yaml
@@ -31,9 +31,6 @@ jobs:
         with:
           r-version: ${{ matrix.config.r }}
 
-      - name: test
-        run: Rscript -e 'print(tools:::.build_packages)'
-
       - uses: r-lib/actions/setup-pandoc@master
 
       - uses: r-lib/actions/setup-tinytex@master
@@ -83,8 +80,8 @@ jobs:
           PGPASSWORD: ${{ env.DBROOTPASS }}
           MYSQL_PWD: ${{ env.DBROOTPASS }}
 
-      - name: test R cmd
-        run: R CMD build .
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v2
 
       - name: Check
         run: Rscript -e "rcmdcheck::rcmdcheck(args = '${{ matrix.config.args }}', error_on = 'note', check_dir = 'check')"

--- a/.github/workflows/check-linux-ubuntu.yaml
+++ b/.github/workflows/check-linux-ubuntu.yaml
@@ -32,7 +32,7 @@ jobs:
           r-version: ${{ matrix.config.r }}
 
       - name: test
-        run: Rscript -e 'installed.packages()["tools",]'
+        run: Rscript -e 'print(tools:::.check_packages)'
 
       - uses: r-lib/actions/setup-pandoc@master
 


### PR DESCRIPTION
Once https://github.com/rstudio/rmarkdown/pull/1832 is on CRAN, this can be removed